### PR TITLE
Mitigate the Search bar API requests

### DIFF
--- a/ultimate-moviegoer-guide/src/App.js
+++ b/ultimate-moviegoer-guide/src/App.js
@@ -21,8 +21,12 @@ function App() {
     else {
       getMovieData(filter, page);
     }
-    getImageData();
   }, [page, filter, query])
+
+  // I want to use a separate useEffect for the imageData because I don't want to call getImageData everytime page, filter, or query is changed. I only want to call it when imageData is changed.
+  useEffect(() =>  {
+    getImageData();
+  }, [imageData])
 
   const getMovieData = async (filter, page) => {
     // We want to construct a url using the filter and page that is passed in.

--- a/ultimate-moviegoer-guide/src/components/Search.js
+++ b/ultimate-moviegoer-guide/src/components/Search.js
@@ -10,12 +10,23 @@ const Search = ({setQuery, setPage}) => {
 		setPage(1);
 	}
 
+	// I needed to add a debouncer so that we aren't requesting data from the API for every keystroke in the Search bar.
+	// It's probably better to pull this function out of here so that it can be used in other areas but since this is a small project I decided to leave it here.
+	const debounce = (func, timeout = 500) => {
+		let timer;
+		return (...args) => {
+			// Anytime a key is pressed we want to reset the timer so we clear it.
+			clearTimeout(timer);
+			timer = setTimeout(() => {func.apply(this, args); }, timeout);
+		};
+	}
+
 	return(
 		<form>
 			<input 
 			type='text' 
 			placeholder='Search for a movie...'
-			onInput={onInputEvent}></input>
+			onInput={debounce(onInputEvent)}></input>
 		</form>
 	);
 }


### PR DESCRIPTION
Previously the Search bar would make an API request anytime a keystroke was made in the search bar. We want to limit the amount of requests if we can so I put a debouncer in the Search component. This will set a timeout for each keystroke.

I also separated the getImageData fetch into its own useEffect. This way we are not requesting image data each time we update the state of page, filter, or query.